### PR TITLE
Fix error logging in review endpoint

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -789,7 +789,7 @@ class AirApi {
             const response = await requestPromise(options)
             return response
         } catch (e) {
-            log.e("Airbnbapi: Couldn't send a review for thread  " + thread_id)
+            log.e("Airbnbapi: Couldn't send a review for thread  " + id)
             log.e(e)
         }
     }


### PR DESCRIPTION
`thread_id` is undefined in sendReview, instead use `id`